### PR TITLE
fix inner parens in bdcatalog commands

### DIFF
--- a/src/main/java/istc/bigdawg/catalog/CatalogUtilities.java
+++ b/src/main/java/istc/bigdawg/catalog/CatalogUtilities.java
@@ -152,9 +152,14 @@ public class CatalogUtilities {
 			parenlevel++;
 			if (phase == CatalogParsingPhases.unstarted) 
 				phase = CatalogParsingPhases.command;
+			else
+				temp.append(token); // seem to need something like this to support INSERT ... VALUES (...)
 			break;
 		case ')':
 			parenlevel--;
+			if (parenlevel > 0) {
+				temp.append(token); // seem to need something like this to support INSERT ... VALUES (...)
+			}
 			break;
 		case '\'':
 			quotedEh = !quotedEh;			


### PR DESCRIPTION
allows parentheses within a bdcatalog() command such that 'bdcatalog(INSERT INTO ... VALUES (...))' style queries (with inner-parens) will work.