### PR TITLE
Fix main for when running in docker with '-d' flag. 

### DIFF
--- a/src/main/java/istc/bigdawg/Main.java
+++ b/src/main/java/istc/bigdawg/Main.java
@@ -21,73 +21,75 @@ import istc.bigdawg.scidb.SciDBHandler;
  */
 public class Main {
 
-	public static String BASE_URI;
-	private static Logger logger;
+    public static String BASE_URI;
+    private static Logger logger;
+    private static MigratorTask migratorTask;
+    private static MonitoringTask relationalTask;
+    private static HttpServer server;
+    private static volatile boolean shutdown;
 
-	/**
-	 * Starts Grizzly HTTP server exposing JAX-RS resources defined in this
-	 * application.
-	 * 
-	 * @param  ipAddress
-	 *         The IP address on which the Grizzly server should wait for requests.
-	 * @return Grizzly HTTP Server.
-	 * @throws IOException
-	 */
-	public static HttpServer startServer(String ipAddress) throws IOException {
-		// exposing the Jersey application at BASE_URI
-		if (ipAddress != null) {
-			BASE_URI = BigDawgConfigProperties.INSTANCE.getBaseURI(ipAddress);
-		} else {
-			BASE_URI = BigDawgConfigProperties.INSTANCE.getBaseURI();
-		}
-		if (logger == null) {
-			// Logger
-			LoggerSetup.setLogging();
-			logger = Logger.getLogger(Main.class);
-		}
+    /**
+     * Starts Grizzly HTTP server exposing JAX-RS resources defined in this
+     * application.
+     *
+     * @param ipAddress The IP address on which the Grizzly server should wait for requests.
+     * @return Grizzly HTTP Server.
+     * @throws IOException
+     */
+    public static HttpServer startServer(String ipAddress) throws IOException {
+        // exposing the Jersey application at BASE_URI
+        if (ipAddress != null) {
+            BASE_URI = BigDawgConfigProperties.INSTANCE.getBaseURI(ipAddress);
+        } else {
+            BASE_URI = BigDawgConfigProperties.INSTANCE.getBaseURI();
+        }
+        if (logger == null) {
+            // Logger
+            LoggerSetup.setLogging();
+            logger = Logger.getLogger(Main.class);
+        }
 
-		logger.info("base uri: " + BASE_URI);
+        logger.info("base uri: " + BASE_URI);
 
         // create a resource config that scans for JAX-RS resources and
-		// providers in istc.bigdawg package
-		final ResourceConfig rc = new ResourceConfig().packages("istc.bigdawg");
+        // providers in istc.bigdawg package
+        final ResourceConfig rc = new ResourceConfig().packages("istc.bigdawg");
 
-		// create and start a new instance of grizzly http server
-		System.out.println("Starting HTTP server on: " + BASE_URI);
-		return GrizzlyHttpServerFactory.createHttpServer(URI.create(BASE_URI), rc);
-	}
+        // create and start a new instance of grizzly http server
+        System.out.println("Starting HTTP server on: " + BASE_URI);
+        return GrizzlyHttpServerFactory.createHttpServer(URI.create(BASE_URI), rc);
+    }
 
-	public static void checkDatabaseConnections() {
-		// Todo: configure these checks based on catalog.engines
-		int postgreSQL1Engine = 0;
-		try {
-			new PostgreSQLHandler(postgreSQL1Engine);
-		} catch (Exception e) {
-			e.printStackTrace();
-			String msg = "QueryClient could not register PostgreSQL handler!";
-			System.err.println(msg);
-			System.exit(1);
-		}
+    public static void checkDatabaseConnections() {
+        // Todo: configure these checks based on catalog.engines
+        int postgreSQL1Engine = 0;
+        try {
+            new PostgreSQLHandler(postgreSQL1Engine);
+        } catch (Exception e) {
+            e.printStackTrace();
+            String msg = "QueryClient could not register PostgreSQL handler!";
+            System.err.println(msg);
+            System.exit(1);
+        }
 //		new AccumuloHandler();
-		try {
-			new SciDBHandler();
-		} catch (SQLException e) {
-			e.printStackTrace();
-			//log.error(e.getMessage() + " " + StackTrace.getFullStackTrace(e));
-		}
-	}
+        try {
+            new SciDBHandler();
+        } catch (SQLException e) {
+            e.printStackTrace();
+            //log.error(e.getMessage() + " " + StackTrace.getFullStackTrace(e));
+        }
+    }
 
-	/**
-	 * Main method. Starts the Catalog, Monitor, Migrator, and HTTP server.
-	 *
+    /**
+     * Main method. Starts the Catalog, Monitor, Migrator, and HTTP server.
+     * <p>
      * Requires Catalog database
      *
-	 * @param args ip address on which the grizzly server should
-     * wait for requests. If empty, then use the configured base uri.
-     *
-	 * @throws IOException
-	 */
-	public static void main(String[] args) throws IOException {
+     * @param args ip address on which the grizzly server should
+     *             wait for requests. If empty, then use the configured base uri.
+     * @throws IOException
+     */
+    public static void main(String[] args) throws IOException {
 
         // Logger
         LoggerSetup.setLogging();
@@ -95,48 +97,78 @@ public class Main {
         logger.info("Starting application ...");
 
         // Catalog
-		logger.info("Connecting to catalog");
-		CatalogInstance.INSTANCE.getCatalog();
+        logger.info("Connecting to catalog");
+        CatalogInstance.INSTANCE.getCatalog();
 
-		logger.info("Checking registered database connections");
-		checkDatabaseConnections();
+        logger.info("Checking registered database connections");
+        checkDatabaseConnections();
+        boolean isConsole = System.console() != null;
 
-        // Monitor
-        MonitoringTask relationalTask = new MonitoringTask();
-		relationalTask.run();
+        synchronized (Main.class) {
+            // Monitor
+            relationalTask = new MonitoringTask();
+            relationalTask.run();
 
-        // Migrator
-        MigratorTask migratorTask = new MigratorTask();
+            // Migrator
+            migratorTask = new MigratorTask();
 
+            // Assign the IP address for the HTTP server to listen on
+            String ipAddress = null;
+            if (args.length > 0) {
+                ipAddress = args[0];
+                logger.debug("args 0: " + args[0]);
+            } else {
+                logger.debug("args length: " + args.length);
+            }
 
+            // ZooKeeperUtils.registerNodeInZooKeeper();
 
-//        // ZooKeeperUtils.registerNodeInZooKeeper();
-//
-//        // S-Store migration task
-//        // SStoreMigrationTask sstoreMigration = new SStoreMigrationTask();
+            // S-Store migration task
+            // SStoreMigrationTask sstoreMigration = new SStoreMigrationTask();
 
-
-        // Assign the IP address for the HTTP server to listen on
-        String ipAddress = null;
-        if (args.length > 0) {
-            ipAddress = args[0];
-            logger.debug("args 0: " + args[0]);
-        } else {
-            logger.debug("args length: " + args.length);
+            // HTTP server
+            server = startServer(ipAddress);
+            System.out.println(String.format(
+                    "Jersey app started with WADL available at %sapplication.wadl\n" +
+                            (isConsole ? "Hit enter to stop it..." : ""),
+                    BASE_URI));
         }
 
-        // HTTP server
-        final HttpServer server = startServer(ipAddress);
-        System.out.println(String.format(
-                "Jersey app started with WADL available at %sapplication.wadl\n" +
-                        "Hit enter to stop it...",
-                BASE_URI));
-        System.in.read();
+        if (isConsole) {
+            System.in.read();
+            Shutdown();
+        } else {
+            // Try to catch the shutdown
+            Runtime.getRuntime().addShutdownHook(new Thread() {
+                public void run() {
+                    try {
+                        Thread.sleep(100);
+                        Shutdown();
+                    } catch (Exception e) {
+                        Thread.currentThread().interrupt();
+                        e.printStackTrace();
+                    }
+                }
+            });
 
+            // Infinite loop until killed.
+            shutdown = false;
+            while (!shutdown) {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                }
+            }
+        }
+    }
+
+    private static synchronized void Shutdown() {
         // Shutdown
+        shutdown = true;
         CatalogInstance.INSTANCE.closeCatalog();
-		migratorTask.close();
-		// ZooKeeperUtils.unregisterNodeInZooKeeper();
-		server.shutdownNow();
-	}
+        migratorTask.close();
+        relationalTask.shutdown();
+        server.shutdownNow();
+        System.exit(0);
+    }
 }

--- a/src/main/java/istc/bigdawg/monitoring/MonitoringTask.java
+++ b/src/main/java/istc/bigdawg/monitoring/MonitoringTask.java
@@ -88,6 +88,10 @@ public class MonitoringTask implements Runnable {
     public void run() {
         this.executor.scheduleAtFixedRate(new Task(this.cores), 0, CHECK_RATE_MS, TimeUnit.MILLISECONDS);
     }
+
+    public void shutdown() {
+        this.executor.shutdown();
+    }
 }
 
 class Task implements Runnable {


### PR DESCRIPTION
When running bigdawg in the background, such as done in [provisions/setup_bigdawg_docker.sh](https://github.com/bigdawg-istc/bigdawg/blob/c45cf94a8021ed9924721ecc7d892cb3e7f762cf/provisions/setup_bigdawg_docker.sh#L167-L170), on certain platforms the System.in.read() call seems to immediately return causing the processes to terminate prematurely.

This is an attempt to fix that problem which seems to work as expected in my testing.

It forks into two code paths, abstracting the shutdown code such that if it's run interactively, the old behavior still works, but if as a daemon, then it register's a shutdown handler which should get called if / when it's killed.

It also fixes the following

   * Proper shutdown of the MonitoringTask (before when you'd hit a key to exit, java would keep running as the MonitoringTask never exited).