### PR TITLE
Fixes scidb/postgres cast calls in docker

### DIFF
--- a/src/main/java/istc/bigdawg/migration/FromDatabaseToDatabase.java
+++ b/src/main/java/istc/bigdawg/migration/FromDatabaseToDatabase.java
@@ -509,9 +509,10 @@ public class FromDatabaseToDatabase implements MigrationNetworkRequest {
 				+ "; hostname to which the data is migrated: " + hostnameTo;
 		log.debug(debugMessage);
 		try {
-			// Todo: fix this check so that docker works
-			//if (!isThisMyIpAddress(InetAddress.getByName(hostnameFrom))) {
-			if (isThisMyIpAddress(InetAddress.getByName(hostnameFrom))) {
+			String localHostName = InetAddress.getLocalHost().getHostName();
+			log.debug("local hostname: " + localHostName);
+
+			if (!localHostName.equals(hostnameFrom)) {
 				log.debug("Source and target hosts are on different IPs. "
 						+ "Migration will be executed remotely (this node: "
 						+ BigDawgConfigProperties.INSTANCE.getGrizzlyIpAddress()
@@ -535,8 +536,8 @@ public class FromDatabaseToDatabase implements MigrationNetworkRequest {
 				// Arrays.asList(thisHostname, hostnameTo), data);
 				// }
 				// if (!isThisMyIpAddress(InetAddress.getByName(hostnameTo))) {
-				if (isThisMyIpAddress(InetAddress.getByName(hostnameTo))) {
-					log.debug("Migration from a local: " + thisHostname
+				if (localHostName.equals(hostnameTo)) {
+					log.debug("Migration from a local: " + thisHostname + " (" + localHostName + ")"
 							+ " to remote database: " + hostnameTo);
 					/*
 					 * The execution through the FollowRemoteNodes will ensure

--- a/src/main/java/istc/bigdawg/migration/FromDatabaseToDatabase.java
+++ b/src/main/java/istc/bigdawg/migration/FromDatabaseToDatabase.java
@@ -14,6 +14,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import istc.bigdawg.api.AbstractApiConnectionInfo;
+import istc.bigdawg.rest.RESTConnectionInfo;
 import org.apache.log4j.Logger;
 import org.apache.zookeeper.KeeperException;
 
@@ -512,7 +514,8 @@ public class FromDatabaseToDatabase implements MigrationNetworkRequest {
 			String localHostName = InetAddress.getLocalHost().getHostName();
 			log.debug("local hostname: " + localHostName);
 
-			if (!localHostName.equals(hostnameFrom)) {
+			if (!localHostName.equals(hostnameFrom) &&
+					!(this.getConnectionFrom() instanceof AbstractApiConnectionInfo)) {
 				log.debug("Source and target hosts are on different IPs. "
 						+ "Migration will be executed remotely (this node: "
 						+ BigDawgConfigProperties.INSTANCE.getGrizzlyIpAddress()


### PR DESCRIPTION
The docker version of bigdawg was getting confused as to which hostname was local and which is remote. This fix should solve that.

It basically changes the comparison from IP based to hostname based, since when running multiple docker containers on the same host, the IP address may get shared, but the hostname should be unique.

It may introduce a regression when running this in production mode, at which case a second patch should be done and perhaps this logic should be a flagged on or off via a property.