### PR TITLE
Patch to drop data sets if they exist prior to trying to create them during migrations

### DIFF
--- a/profiles/dev/dev-config.properties
+++ b/profiles/dev/dev-config.properties
@@ -132,3 +132,10 @@ sstore.alerturl=http://localhost:7777/test
 #zooKeepers=192.168.99.100:2181
 zooKeepers=128.30.76.163:2181
 #zooKeepers=madison-master:2181,addison-slave:2181,division-slave:2181,francisco-slave:2181,wellington-slave:2181
+
+# Set these up so that migrations drop the dataset before creating it.
+postgresql.dropdataset=true
+mysql.dropdataset=true
+vertica.dropdataset=true
+accumulo.dropdataset=true
+scidb.dropdataset=true

--- a/profiles/localhost/localhost-config.properties
+++ b/profiles/localhost/localhost-config.properties
@@ -3,7 +3,7 @@
 # ==================
 
 grizzly.ipaddress=localhost
-grizzly.port=8080
+grizzly.port=8081
 
 # ==================
 # Catalog database
@@ -104,3 +104,10 @@ cmigrator.dir=src/main/cmigrator/build/
 sstore.alerturl=http://localhost:7777/test
 
 zooKeepers=localhost:2181
+
+# Set these up so that migrations drop the dataset before creating it.
+postgresql.dropdataset=true
+mysql.dropdataset=true
+vertica.dropdataset=true
+accumulo.dropdataset=true
+scidb.dropdataset=true

--- a/profiles/localhost/localhost-config.properties
+++ b/profiles/localhost/localhost-config.properties
@@ -3,6 +3,7 @@
 # ==================
 
 grizzly.ipaddress=localhost
+# Use 8081 so that the docker postgres catalog container can be run as-is while running this outside of the container/locally.
 grizzly.port=8081
 
 # ==================

--- a/profiles/mit-debug/mit-debug-config.properties
+++ b/profiles/mit-debug/mit-debug-config.properties
@@ -116,4 +116,11 @@ sstore.alerturl=http://localhost:7777/test
 
 #zooKeepers=localhost:37266
 zooKeepers=localhost:2181
-#zooKeepers=madison-master:2181,addison-slave:2181,division-slave:2181,francisco-slave:2181,wellington-slave:2181
+#zooKeeers=madison-master:2181,addison-slave:2181,division-slave:2181,francisco-slave:2181,wellington-slave:2181
+
+# Set these up so that migrations drop the dataset before creating it.
+postgresql.dropdataset=true
+mysql.dropdataset=true
+vertica.dropdataset=true
+accumulo.dropdataset=true
+scidb.dropdataset=true

--- a/profiles/mit/mit-config.properties
+++ b/profiles/mit/mit-config.properties
@@ -87,7 +87,7 @@ network.data.port=9992
 # the timeout in ms: how long should we wait for reply
 #(this if for heart beat message to check if a remote machine
 # is up and running)
-network.request.timeout=5000
+network.request.timeout=30000
 
 # How many times should we retry the connection to the server to send the data?
 network.retry.connection=2

--- a/profiles/mit/mit-config.properties
+++ b/profiles/mit/mit-config.properties
@@ -104,3 +104,10 @@ cmigrator.dir=src/main/cmigrator/build/
 sstore.alerturl=http://localhost:7777/test
 
 zooKeepers=192.168.99.100:2181
+
+# Set these up so that migrations drop the dataset before creating it.
+postgresql.dropdataset=true
+mysql.dropdataset=true
+vertica.dropdataset=true
+accumulo.dropdataset=true
+scidb.dropdataset=true

--- a/src/main/java/istc/bigdawg/accumulo/AccumuloInstance.java
+++ b/src/main/java/istc/bigdawg/accumulo/AccumuloInstance.java
@@ -237,6 +237,14 @@ public class AccumuloInstance {
 		return conn;
 	}
 
+	public void dropDataSetIfExists(String dataSetName) throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
+		if (getConnector().tableOperations().exists(dataSetName)) {
+			getConnector().tableOperations().delete(dataSetName);
+		} else {
+			logger.debug("Accumulo Table "+dataSetName+" does not exist; skip dropping.");
+		}
+	}
+
 	public boolean createTableIfNotExists(String tableName) throws Exception {
 		TableOperations tabOp = getConnector().tableOperations();
 		if (!tabOp.exists(tableName)) {

--- a/src/main/java/istc/bigdawg/cast/CastOverseer.java
+++ b/src/main/java/istc/bigdawg/cast/CastOverseer.java
@@ -39,7 +39,6 @@ public class CastOverseer {
 	 * @param cast
 	 * @param source
 	 * @param target
-	 * @param targetDBID
 	 * @param connectionInfoMap
 	 * @param tempTableInfo
 	 * @return the object identity, oid, of intermediate result table on remote database
@@ -109,7 +108,7 @@ public class CastOverseer {
 			}
 			tempTableInfo.get(connectionInfoMap.get(source)).add(source.getName());
 			try {
-				Migrator.migrate(connectionInfoMap.get(source), source.getName(), targetConnInfo, remoteName, new MigrationParams(cast.getQueryString(), source, target));
+				Migrator.migrate(connectionInfoMap.get(source), source.getName(), targetConnInfo, remoteName, new MigrationParams(cast.getName(), cast.getQueryString(), source, target));
 			} catch (MigrationException e) {
 				logger.error(StackTrace.getFullStackTrace(e));
 				throw new CastException(e.getMessage(), e);

--- a/src/main/java/istc/bigdawg/migration/FromAccumuloToPostgres.java
+++ b/src/main/java/istc/bigdawg/migration/FromAccumuloToPostgres.java
@@ -14,10 +14,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import org.apache.accumulo.core.client.AccumuloException;
@@ -161,11 +158,12 @@ public class FromAccumuloToPostgres extends FromDatabaseToDatabase {
 					+ "PostgreSQL, if so create it.");
 			String createStatement = MigrationUtils
 					.getUserCreateStatement(migrationInfo);
+			Optional<String> name = migrationInfo.getMigrationParams().flatMap(MigrationParams::getName);
 			if (createStatement != null) {
 				logger.debug(
 						"The create table statement to be executed in PostgreSQL: "
 								+ createStatement);
-				PostgreSQLHandler.createTargetTableSchema(con,
+				PostgreSQLHandler.createTargetTableSchema(con, name.orElse(null),
 						migrationInfo.getObjectTo(), createStatement);
 			}
 		} catch (SQLException e) {

--- a/src/main/java/istc/bigdawg/migration/FromPostgresToAccumulo.java
+++ b/src/main/java/istc/bigdawg/migration/FromPostgresToAccumulo.java
@@ -15,6 +15,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import istc.bigdawg.properties.BigDawgConfigProperties;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchWriter;
@@ -162,6 +163,9 @@ public class FromPostgresToAccumulo extends FromDatabaseToDatabase {
 
 		try {
 			this.accInst = AccumuloInstance.getFullInstance(conTo);
+			if (BigDawgConfigProperties.INSTANCE.isAccumuloDropDataSet()) {
+				accInst.dropDataSetIfExists(migrationInfo.getObjectTo());
+			}
 			accInst.createTableIfNotExists(migrationInfo.getObjectTo());
 		} catch (Exception e) {
 			throw new MigrationException("Problem with Accumulo", e);
@@ -377,7 +381,7 @@ public class FromPostgresToAccumulo extends FromDatabaseToDatabase {
 
 		AccumuloInstance accInst = tpch.getAccumuloInstance();
 		for (String tableName : tables) {
-			accInst.deleteTable(tableName);
+			accInst.dropDataSetIfExists(tableName);
 			accInst.createTable(tableName);
 		}
 

--- a/src/main/java/istc/bigdawg/migration/FromRESTToAccumulo.java
+++ b/src/main/java/istc/bigdawg/migration/FromRESTToAccumulo.java
@@ -19,6 +19,7 @@ import java.util.StringJoiner;
 
 import istc.bigdawg.executor.RESTQueryResult;
 import istc.bigdawg.islands.IntraIslandQuery;
+import istc.bigdawg.properties.BigDawgConfigProperties;
 import istc.bigdawg.rest.RESTConnectionInfo;
 import istc.bigdawg.utils.Tuple;
 import org.apache.accumulo.core.client.AccumuloException;
@@ -107,6 +108,9 @@ public class FromRESTToAccumulo extends FromDatabaseToDatabase {
         conTo = (AccumuloConnectionInfo) migrationInfo.getConnectionTo();
         try {
             this.accInst = AccumuloInstance.getFullInstance(conTo);
+            if (BigDawgConfigProperties.INSTANCE.isAccumuloDropDataSet()) {
+                accInst.dropDataSetIfExists(migrationInfo.getObjectTo());
+            }
             accInst.createTableIfNotExists(migrationInfo.getObjectTo());
         } catch (Exception e) {
             throw new MigrationException("Problem with Accumulo", e);

--- a/src/main/java/istc/bigdawg/migration/FromSStoreToPostgresImplementation.java
+++ b/src/main/java/istc/bigdawg/migration/FromSStoreToPostgresImplementation.java
@@ -15,6 +15,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
 
+import istc.bigdawg.properties.BigDawgConfigProperties;
+import istc.bigdawg.relational.RelationalHandler;
 import org.apache.log4j.Logger;
 
 import istc.bigdawg.exceptions.MigrationException;
@@ -185,7 +187,7 @@ public class FromSStoreToPostgresImplementation implements MigrationImplementati
 
 	    String createTableStatement = null;
 	    createTableStatement = getCreatePostgreSQLTableStatementFromSStoreTable();
-	    createTargetTableSchema(connectionPostgres, createTableStatement);
+	    createTargetTableSchema(connectionPostgres, toTable, createTableStatement);
 	    
 	    CopyToPostgresExecutor loadExecutor = new CopyToPostgresExecutor(connectionPostgres,
 			PostgreSQLHandler.getLoadBinCommand(toTable), sStorePipe);
@@ -289,9 +291,12 @@ public class FromSStoreToPostgresImplementation implements MigrationImplementati
 	 * 
 	 * @throws SQLException
 	 */
-	private void createTargetTableSchema(Connection postgresCon, String createTableStatement) throws SQLException {
+	private void createTargetTableSchema(Connection postgresCon, String toTable, String createTableStatement) throws SQLException {
 		PostgreSQLSchemaTableName schemaTable = new PostgreSQLSchemaTableName(toTable);
 		PostgreSQLHandler.executeStatement(postgresCon, "create schema if not exists " + schemaTable.getSchemaName());
+		if (BigDawgConfigProperties.INSTANCE.isPostgreSQLDropDataSet()) {
+			PostgreSQLHandler.executeStatement(postgresCon, RelationalHandler.getDropTableStatement(toTable));
+		}
 		PostgreSQLHandler.executeStatement(postgresCon, createTableStatement);
 	}
 

--- a/src/main/java/istc/bigdawg/migration/LoadPostgres.java
+++ b/src/main/java/istc/bigdawg/migration/LoadPostgres.java
@@ -223,7 +223,7 @@ public class LoadPostgres implements Load {
 							.getCreatePostgreSQLTableStatement(
 									migrationInfo.getObjectTo(), attributes);
 					PostgreSQLHandler.createTargetTableSchema(connection,
-							migrationInfo.getObjectTo(), createTableStatement);
+							migrationInfo.getObjectTo(), migrationInfo.getObjectTo(), createTableStatement);
 				}
 			}
 		} catch (SQLException e) {

--- a/src/main/java/istc/bigdawg/migration/MigrationParams.java
+++ b/src/main/java/istc/bigdawg/migration/MigrationParams.java
@@ -23,6 +23,7 @@ public class MigrationParams implements Serializable {
 	private static final long serialVersionUID = -7869941786159490966L;
 	/** see: {@link #getCreateStatement()} */
 	private String createStatement;
+	private String name;
 
 	transient private IntraIslandQuery source;
 	transient private IntraIslandQuery target;
@@ -36,11 +37,22 @@ public class MigrationParams implements Serializable {
 		this.createStatement = createStatement;
 	}
 
+	public MigrationParams(String createStatement, String name) {
+		this(createStatement);
+		this.name = name;
+	}
+
 	public MigrationParams(String createStatement, IntraIslandQuery source, IntraIslandQuery target) {
 		this(createStatement);
 		this.source = source;
 		this.target = target;
 	}
+
+	public MigrationParams(String name, String createStatement, IntraIslandQuery source, IntraIslandQuery target) {
+		this(createStatement, source, target);
+		this.name = name;
+	}
+
 
 	/**
 	 * The create statement (for array/table/object) which was passed directly
@@ -53,6 +65,16 @@ public class MigrationParams implements Serializable {
 	public Optional<String> getCreateStatement() {
 		return Optional.ofNullable(createStatement);
 	}
+
+	/**
+	 * The name (for array/table/object) used in the corresponding create statement (if any).
+	 *
+	 * @return the array/table/object name.
+	 */
+	public Optional<String> getName() {
+		return Optional.ofNullable(name);
+	}
+
 
 	/*
 	 * (non-Javadoc)
@@ -86,6 +108,12 @@ public class MigrationParams implements Serializable {
 			if (other.createStatement != null)
 				return false;
 		} else if (!createStatement.equals(other.createStatement))
+			return false;
+
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
 			return false;
 
 		if (source != other.source) {

--- a/src/main/java/istc/bigdawg/migration/MigrationUtils.java
+++ b/src/main/java/istc/bigdawg/migration/MigrationUtils.java
@@ -4,12 +4,9 @@
 package istc.bigdawg.migration;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
+import istc.bigdawg.properties.BigDawgConfigProperties;
 import org.apache.log4j.Logger;
 
 import istc.bigdawg.database.AttributeMetaData;
@@ -43,6 +40,12 @@ public class MigrationUtils {
 	 * this is a temporal variable for consumer from a lambda function
 	 */
 	private static String createStatement = null;
+
+	/*
+	 * The statement to be used in a database to create an object (table/array,
+	 * this is a temporal variable for consumer from a lambda function
+	 */
+	private static String name = null;
 
 	/**
 	 * Check if this is a flat array in SciDB.
@@ -343,6 +346,10 @@ public class MigrationUtils {
 			}
 			SciDBHandler localHandler = new SciDBHandler(
 					migrationInfo.getConnectionTo());
+			Optional<String> name = migrationInfo.getMigrationParams().flatMap(MigrationParams::getName);
+			if (name.isPresent() && BigDawgConfigProperties.INSTANCE.isScidbDropDataSet()) {
+				localHandler.dropDataSetIfExists(name.get());
+			}
 			localHandler.execute(createArrayStatement);
 //			localHandler.commit();
 //			localHandler.close();

--- a/src/main/java/istc/bigdawg/mysql/MySQLHandler.java
+++ b/src/main/java/istc/bigdawg/mysql/MySQLHandler.java
@@ -307,7 +307,7 @@ public class MySQLHandler implements RelationalHandler {
 
 	@Override
 	public void dropDataSetIfExists(String dataSetName) throws Exception {
-
+		executeQuery(RelationalHandler.getDropTableStatement(dataSetName));
 	}
 
 	/**
@@ -533,7 +533,7 @@ public class MySQLHandler implements RelationalHandler {
 	}
 
 	public void dropTableIfExists(String tableName) throws SQLException {
-		executeStatementOnConnection("drop table if exists " + tableName);
+		executeStatementOnConnection(RelationalHandler.getDropTableStatement(tableName));
 	}
 
 	/**

--- a/src/main/java/istc/bigdawg/postgresql/PostgreSQLHandler.java
+++ b/src/main/java/istc/bigdawg/postgresql/PostgreSQLHandler.java
@@ -37,6 +37,7 @@ import istc.bigdawg.query.ConnectionInfo;
 import istc.bigdawg.query.QueryClient;
 import istc.bigdawg.utils.LogUtils;
 import istc.bigdawg.utils.StackTrace;
+import org.restlet.resource.Post;
 
 /**
  * @author Adam Dziedzic
@@ -852,7 +853,7 @@ public class PostgreSQLHandler implements RelationalHandler {
 	 * @throws SQLException
 	 */
 	public void dropDataSetIfExists(String tableName) throws SQLException {
-		executeStatementOnConnection("drop table if exists " + tableName);
+		executeStatementOnConnection(RelationalHandler.getDropTableStatement(tableName));
 	}
 
 	/**
@@ -872,11 +873,14 @@ public class PostgreSQLHandler implements RelationalHandler {
 	 * @throws NoTargetArrayException
 	 */
 	public static void createTargetTableSchema(Connection postgresCon,
-			String toTable, String createTableStatement) throws SQLException {
+			String name, String toTable, String createTableStatement) throws SQLException {
 		PostgreSQLSchemaTableName schemaTable = new PostgreSQLSchemaTableName(
 				toTable);
 		PostgreSQLHandler.executeStatement(postgresCon,
 				"create schema if not exists " + schemaTable.getSchemaName());
+		if (name != null && BigDawgConfigProperties.INSTANCE.isPostgreSQLDropDataSet()) {
+			PostgreSQLHandler.executeStatement(postgresCon, RelationalHandler.getDropTableStatement(name));
+		}
 		PostgreSQLHandler.executeStatement(postgresCon, createTableStatement);
 	}
 

--- a/src/main/java/istc/bigdawg/properties/BigDawgConfigProperties.java
+++ b/src/main/java/istc/bigdawg/properties/BigDawgConfigProperties.java
@@ -17,6 +17,7 @@ public enum BigDawgConfigProperties {
 	private String postgreSQLURL;
 	private String postgreSQLUser;
 	private String postgreSQLPassword;
+	private boolean postgreSQLDropDataSet;
 
 	private String postgreSQLTestHost;
 	private String postgreSQLTestPort;
@@ -29,12 +30,15 @@ public enum BigDawgConfigProperties {
 	private String mySQLTestDatabase;
 	private String mySQLTestUser;
 	private String mySQLTestPassword;
+	private boolean mySQLDropDataSet;
+	private boolean verticaDropDataSet;
 
 	private int accumuloSchemaServerDBID;
 	private String accumuloIstanceType;
 	private String accumuloIstanceName;
 	private String accumuloUser;
 	private String accumuloPasswordToken;
+	private boolean accumuloDropDataSet;
 
 	private int scidbSchemaServerDBID;
 	private String scidbHostname;
@@ -42,6 +46,7 @@ public enum BigDawgConfigProperties {
 	private String scidbUser;
 	private String scidbPassword;
 	private String scidbBinPath;
+	private boolean scidbDropDataSet;
 
 	private String scidbTestHostname;
 	private String scidbTestPort;
@@ -98,6 +103,7 @@ public enum BigDawgConfigProperties {
 		this.postgreSQLURL = prop.getProperty("main.postgresql.url");
 		this.postgreSQLUser = prop.getProperty("main.postgresql.user");
 		this.postgreSQLPassword = prop.getProperty("main.postgresql.password");
+		this.postgreSQLDropDataSet = Boolean.valueOf(prop.getProperty("main.postgresql.dropdataset"));
 
 		this.postgreSQLTestHost = prop.getProperty("main.postgresql.test.host");
 		this.postgreSQLTestPort = prop.getProperty("main.postgresql.test.port");
@@ -114,6 +120,8 @@ public enum BigDawgConfigProperties {
 		this.mySQLTestUser = prop.getProperty("main.mysql.test.user");
 		this.mySQLTestPassword = prop
 				.getProperty("main.mysql.test.password");
+		this.mySQLDropDataSet = Boolean.valueOf(prop.getProperty("main.mysql.dropdataset"));
+		this.verticaDropDataSet = Boolean.valueOf(prop.getProperty("main.vertica.dropdataset"));
 
 		this.accumuloSchemaServerDBID = Integer
 				.parseInt(prop.getProperty("main.accumulo.dbid.schema"));
@@ -126,6 +134,7 @@ public enum BigDawgConfigProperties {
 				.getProperty("main.accumulo.passwordToken");
 		this.accumuloShellScript = prop
 				.getProperty("main.accumulo.shell.script");
+		this.accumuloDropDataSet = Boolean.valueOf(prop.getProperty("main.accumulo.dropdataset"));
 
 		this.sstoreDBID =Integer.parseInt(prop.getProperty("main.sstore.dbid"));
 		this.sStoreURL = prop.getProperty("main.sstore.alerturl");
@@ -150,6 +159,7 @@ public enum BigDawgConfigProperties {
 		this.scidbPassword = prop.getProperty("main.scidb.password");
 		this.scidbUser = prop.getProperty("main.scidb.user");
 		this.scidbBinPath = prop.getProperty("main.scidb.bin_path");
+		this.scidbDropDataSet = Boolean.valueOf(prop.getProperty("main.scidb.dropdataset"));
 
 		this.scidbTestHostname = prop.getProperty("main.scidb.test.hostname");
 		this.scidbTestPort = prop.getProperty("main.scidb.test.port");
@@ -495,4 +505,23 @@ public enum BigDawgConfigProperties {
 		return accumuloSchemaServerDBID;
 	}
 
+	public boolean isPostgreSQLDropDataSet() {
+		return postgreSQLDropDataSet;
+	}
+
+	public boolean isMySQLDropDataSet() {
+		return mySQLDropDataSet;
+	}
+
+	public boolean isAccumuloDropDataSet() {
+		return accumuloDropDataSet;
+	}
+
+	public boolean isScidbDropDataSet() {
+		return scidbDropDataSet;
+	}
+
+	public boolean isVerticaDropDataSet() {
+		return verticaDropDataSet;
+	}
 }

--- a/src/main/java/istc/bigdawg/relational/RelationalHandler.java
+++ b/src/main/java/istc/bigdawg/relational/RelationalHandler.java
@@ -110,6 +110,10 @@ public interface RelationalHandler extends DBHandler, ExecutorEngine {
 		}
 	}
 
+	public static String getDropTableStatement(String tableName) {
+		return "drop table if exists " + tableName;
+	}
+
 	/**
 	 * Executes a statement (not a query). It cleans the resources
 	 * at the end.

--- a/src/main/java/istc/bigdawg/vertica/VerticaHandler.java
+++ b/src/main/java/istc/bigdawg/vertica/VerticaHandler.java
@@ -521,7 +521,7 @@ public class VerticaHandler implements RelationalHandler {
     }
 
     public void dropTableIfExists(String tableName) throws SQLException {
-        executeStatementOnConnection("drop table if exists " + tableName);
+        executeStatementOnConnection(RelationalHandler.getDropTableStatement(tableName));
     }
 
     @Override

--- a/src/main/resources/bigdawg-config.properties
+++ b/src/main/resources/bigdawg-config.properties
@@ -1,6 +1,13 @@
 main.grizzly.ipaddress=${grizzly.ipaddress}
 main.grizzly.port=${grizzly.port}
 
+# Whether to drop data sets (if exists) before creating the import tables during the migration commands.
+main.postgresql.dropdataset=${postgresql.dropdataset}
+main.accumulo.dropdataset=${accumulo.dropdataset}
+main.scidb.dropdataset=${scidb.dropdataset}
+main.mysql.dropdataset=${mysql.dropdataset}
+main.vertica.dropdataset=%{vertica.dropdataset}
+
 main.postgresql.dbid.schema = ${postgresql.dbid.schema}
 main.scidb.dbid.schema = ${scidb.dbid.schema}
 main.sstore.dbid = ${sstore.dbid}

--- a/src/test/java/istc/bigdawg/migration/FromAccumuloToPostgresTest.java
+++ b/src/test/java/istc/bigdawg/migration/FromAccumuloToPostgresTest.java
@@ -78,9 +78,7 @@ public class FromAccumuloToPostgresTest {
 				return;
 			}
 			try {
-				PostgreSQLHandler.executeStatement(con,
-						"drop table if exists " + TABLE);
-				PostgreSQLHandler.createTargetTableSchema(con, TABLE,
+				PostgreSQLHandler.createTargetTableSchema(con, TABLE, TABLE,
 						CREATE_TABLE);
 			} catch (SQLException e1) {
 				logger.error("Could not create table in PostgreSQL.");
@@ -155,9 +153,7 @@ public class FromAccumuloToPostgresTest {
 			return;
 		}
 		try {
-			PostgreSQLHandler.executeStatement(con,
-					"drop table if exists " + TABLE);
-			PostgreSQLHandler.createTargetTableSchema(con, TABLE, CREATE_TABLE);
+			PostgreSQLHandler.createTargetTableSchema(con, TABLE, TABLE, CREATE_TABLE);
 			con.commit();
 			con.close();
 		} catch (SQLException e1) {
@@ -192,7 +188,7 @@ public class FromAccumuloToPostgresTest {
 		PostgreSQLHandler postgresHandler = new PostgreSQLHandler(connectionTo);
 		postgresHandler
 				.executeStatementPostgreSQL("drop table if exists " + tableTo);
-		MigrationParams params = new MigrationParams("create table " + tableTo
+		MigrationParams params = new MigrationParams(tableTo, "create table " + tableTo
 				+ " (" + AccumuloTest.COL_QUAL + " varchar)");
 		Migrator.migrate(connectionFrom, tableFrom, connectionTo, tableTo,
 				params);

--- a/src/test/java/istc/bigdawg/migration/FromPostgresToPostgresTest.java
+++ b/src/test/java/istc/bigdawg/migration/FromPostgresToPostgresTest.java
@@ -155,7 +155,7 @@ public class FromPostgresToPostgresTest {
 				"localhost", "5431", "test", "pguser", localPassword);
 		PostgreSQLConnectionInfo conInfoTo = new PostgreSQLConnectionInfo(
 				"localhost", "5430", "test", "pguser", localPassword);
-		migrationParams = new MigrationParams(getCreateTableTest(tableNameTo));
+		migrationParams = new MigrationParams(tableNameTo, getCreateTableTest(tableNameTo));
 		migrateTest(conInfoFrom, conInfoTo);
 	}
 

--- a/src/test/java/istc/bigdawg/migration/FromSciDBToPostgresTest.java
+++ b/src/test/java/istc/bigdawg/migration/FromSciDBToPostgresTest.java
@@ -98,7 +98,7 @@ public class FromSciDBToPostgresTest {
 
 		PostgreSQLHandler handler = new PostgreSQLHandler(conTo);
 		handler.dropDataSetIfExists(toTable);
-		MigrationParams migrationParams = new MigrationParams(
+		MigrationParams migrationParams = new MigrationParams(toTable,
 				TestMigrationUtils.getCreateRegionTableStatement(toTable));
 		/* We migrate from the multi-dimensional array so drop to flat one. */
 		SciDBHandler.dropArrayIfExists(conFrom, flatArray);


### PR DESCRIPTION
If a migration fails for some reason (process crash, system down, etc.) a temporary table can get left around, such that the next time a cast/migration is attempted, it will fail creating the temporary table as it already exists.

The solution is to try and drop the temporary table/dataset before creating it.

Given that dropping tables in a database could be potentially catastrophic in production if there's some kind of bug, it's flagged so that it can be turned on and off (default 'off' in production, but should be 'on' for the docker build, for example).

