### PR TITLE
Address Issue #15 by attempting to distinguish join types

### DIFF
--- a/src/main/java/istc/bigdawg/islands/SciDB/operators/SciDBIslandJoin.java
+++ b/src/main/java/istc/bigdawg/islands/SciDB/operators/SciDBIslandJoin.java
@@ -260,6 +260,9 @@ public class SciDBIslandJoin extends SciDBIslandOperator implements Join {
 		return null;
 	}
 
-
+	@Override
+	public JoinType getJoinType() {
+    	return joinType;
+	}
 	
 };

--- a/src/main/java/istc/bigdawg/islands/operators/Join.java
+++ b/src/main/java/istc/bigdawg/islands/operators/Join.java
@@ -4,7 +4,9 @@ import istc.bigdawg.exceptions.IslandException;
 
 public interface Join extends Operator {
 
-	public enum JoinType  {Left, Natural, Right, Cross};
+	// Need to suppor the following join types
+	// https://github.com/postgres/postgres/blob/ab7646ff92c799303b9ee70ce88b89e07dae717c/src/backend/commands/explain.c#L1475
+	public enum JoinType  {Left, Natural, Right, Cross, Inner, Full, Semi, Anti, Simple};
 	
 	// creates a default and call this to create a new Join instance
 	public Join construct(Operator child0, Operator child1, JoinType jt, String joinPred, boolean isFilter) throws Exception;
@@ -26,5 +28,5 @@ public interface Join extends Operator {
 	public String getJoinToken();	
 	public Integer getJoinID();
 	public void setJoinID(Integer joinID);
-
+	public JoinType getJoinType();
 };

--- a/src/main/java/istc/bigdawg/islands/relational/SQLTableExpression.java
+++ b/src/main/java/istc/bigdawg/islands/relational/SQLTableExpression.java
@@ -76,6 +76,10 @@ public class SQLTableExpression {
     	parsedStatement = s;
     }
 
+    public PlainSelect getSelect() {
+    	return parsedStatement;
+	}
+
     public void addJoin(Join j) {
     	joins.add(j);
     }

--- a/src/main/java/istc/bigdawg/islands/relational/operators/SQLIslandJoin.java
+++ b/src/main/java/istc/bigdawg/islands/relational/operators/SQLIslandJoin.java
@@ -44,12 +44,14 @@ public class SQLIslandJoin extends SQLIslandOperator implements Join {
 		super(parameters, output, lhs, rhs, supplement);
 
 		// mending non-canoncial ordering
+		boolean flipJoinType = false;
 		if (children.get(0) instanceof SQLIslandScan && !(children.get(1) instanceof SQLIslandScan)) {
 			SQLIslandOperator child0 = (SQLIslandOperator) children.get(1);
 			SQLIslandOperator child1 = (SQLIslandOperator) children.get(0);
 			children.clear();
 			children.add(child0);
 			children.add(child1);
+			flipJoinType = true;
 		}
 		
 		this.isBlocking = false;
@@ -104,6 +106,14 @@ public class SQLIslandJoin extends SQLIslandOperator implements Join {
 		if (parameters.containsKey("Join-Type")) {
 			try {
 				joinType = JoinType.valueOf(parameters.get("Join-Type"));
+				// Have to potentially flip the join type as well.
+				if (flipJoinType) {
+					if (joinType == JoinType.Left) {
+						joinType = JoinType.Right;
+					} else if (joinType == JoinType.Right) {
+						joinType = JoinType.Left;
+					}
+				}
 			} catch (IllegalArgumentException e) {
 				// unknown join type
 				Logger.getLogger(this.getClass().getName()).warn("Unknown Join-Type returned: '" + parameters.get("Join-Type") + "'");
@@ -168,7 +178,7 @@ public class SQLIslandJoin extends SQLIslandOperator implements Join {
 	
 	public SQLIslandJoin(Operator child0, Operator child1, JoinType jt, String joinPred, boolean isFilter) throws JSQLParserException {
 		this.isCTERoot = false; // TODO VERIFY
-		this.isBlocking = false; 
+		this.isBlocking = false;
 		this.isPruned = false;
 		this.isCopy = true;
 		this.setAliases(new ArrayList<>());
@@ -209,7 +219,7 @@ public class SQLIslandJoin extends SQLIslandOperator implements Join {
 	
 	public SQLIslandJoin() {
 		super();
-		
+
 		this.isCTERoot = false; // TODO VERIFY
 		this.isBlocking = false;
 		this.isPruned = false;
@@ -222,7 +232,7 @@ public class SQLIslandJoin extends SQLIslandOperator implements Join {
 
 	@Override
 	public Join construct(Operator child0, Operator child1, JoinType jt, String joinPred, boolean isFilter) throws Exception {
-		
+
 		this.isCopy = true; 
 		
 		if (jt != null) this.joinType = jt;

--- a/src/main/java/istc/bigdawg/islands/relational/operators/SQLIslandJoin.java
+++ b/src/main/java/istc/bigdawg/islands/relational/operators/SQLIslandJoin.java
@@ -22,6 +22,7 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.Parenthesis;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Column;
+import org.apache.log4j.Logger;
 
 
 public class SQLIslandJoin extends SQLIslandOperator implements Join {
@@ -97,6 +98,15 @@ public class SQLIslandJoin extends SQLIslandOperator implements Join {
 		for (Operator o : children) {
 			if (o instanceof SQLIslandAggregate) {
 				((SQLIslandAggregate)o).setSingledOutAggregate();
+			}
+		}
+
+		if (parameters.containsKey("Join-Type")) {
+			try {
+				joinType = JoinType.valueOf(parameters.get("Join-Type"));
+			} catch (IllegalArgumentException e) {
+				// unknown join type
+				Logger.getLogger(this.getClass().getName()).warn("Unknown Join-Type returned: '" + parameters.get("Join-Type") + "'");
 			}
 		}
 		
@@ -446,5 +456,10 @@ public class SQLIslandJoin extends SQLIslandOperator implements Join {
 	@Override
 	public String generateJoinFilter() throws IslandException {
 		return joinFilter != null ? new String(joinFilter): null;
+	}
+
+	@Override
+	public JoinType getJoinType() {
+		return joinType;
 	}
 };

--- a/src/main/java/istc/bigdawg/islands/relational/operators/SQLIslandOperator.java
+++ b/src/main/java/istc/bigdawg/islands/relational/operators/SQLIslandOperator.java
@@ -30,7 +30,7 @@ import net.sf.jsqlparser.util.SelectUtils;
 public class SQLIslandOperator implements Operator {
 
 	
-	static final String BigDAWGSQLPrunePrefix = "BIGDAWGSQLPRUNED_"; 
+	static final String BigDAWGSQLPrunePrefix = "BIGDAWGSQLPRUNED_";
 	static final String BigDAWGSQLSubtreePrefix = "BIGDAWGSQLSUBTREE_";
 	
 	protected boolean isBlocking = false; 
@@ -58,7 +58,8 @@ public class SQLIslandOperator implements Operator {
 	
 	protected Set<String> dataObjects;
 	private Set<String> objectAliases = null;
-	
+
+	protected SQLTableExpression supplement;
 	// SQL, single non sort non union
 	public SQLIslandOperator(Map<String, String> parameters, List<String> output,  
 			SQLIslandOperator child, // this is changed to 
@@ -73,7 +74,8 @@ public class SQLIslandOperator implements Operator {
 			
 			populateComplexOutItem(true);
 		}
-		
+
+		this.supplement = supplement;
 	}
 
 	
@@ -91,7 +93,7 @@ public class SQLIslandOperator implements Operator {
 		rhs.setParent(this);
 		
 		populateComplexOutItem(true);
-		
+		this.supplement = supplement;
 	}
 	
 	// SQL, UNION
@@ -104,7 +106,7 @@ public class SQLIslandOperator implements Operator {
 		children.addAll(childs);
 		for (SQLIslandOperator c : childs) c.setParent(this);
 		populateComplexOutItem(true);
-		
+		this.supplement = supplement;
 	}
 	
 	
@@ -563,5 +565,9 @@ public class SQLIslandOperator implements Operator {
 	public Integer getPruneID() {
 		if (isPruned) return pruneID;
 		else return null;
+	}
+
+	public SQLTableExpression getSupplement() {
+		return supplement;
 	}
 }

--- a/src/main/java/istc/bigdawg/network/DataIn.java
+++ b/src/main/java/istc/bigdawg/network/DataIn.java
@@ -16,7 +16,6 @@ import java.util.concurrent.Callable;
 import org.apache.log4j.Logger;
 
 import istc.bigdawg.utils.StackTrace;
-import scala.annotation.meta.param;
 
 /**
  * The server which receives (large amount of) data from network.

--- a/src/main/java/istc/bigdawg/postgresql/PostgreSQLHandler.java
+++ b/src/main/java/istc/bigdawg/postgresql/PostgreSQLHandler.java
@@ -37,7 +37,6 @@ import istc.bigdawg.query.ConnectionInfo;
 import istc.bigdawg.query.QueryClient;
 import istc.bigdawg.utils.LogUtils;
 import istc.bigdawg.utils.StackTrace;
-import org.restlet.resource.Post;
 
 /**
  * @author Adam Dziedzic

--- a/src/main/java/istc/bigdawg/shims/PostgreSQLQueryGenerator.java
+++ b/src/main/java/istc/bigdawg/shims/PostgreSQLQueryGenerator.java
@@ -1930,29 +1930,31 @@ public class PostgreSQLQueryGenerator implements OperatorQueryGenerator {
 	private net.sf.jsqlparser.statement.select.Join addJSQLParserJoin(Select dstStatement, Table t, JoinType joinType) {
 		net.sf.jsqlparser.statement.select.Join newJ = new net.sf.jsqlparser.statement.select.Join();
 		newJ.setRightItem(t);
-		switch(joinType) {
-			case Simple:
-				newJ.setSimple(true);
-				break;
-			case Left:
-				newJ.setLeft(true);
-				break;
-			case Right:
-				newJ.setRight(true);
-				break;
-			case Cross:
-				newJ.setCross(true);
-				break;
-			case Full:
-				newJ.setFull(true);
-				break;
-			case Inner:
-				newJ.setInner(true);
-				break;
-			default:
-				Logger.getLogger(PostgreSQLQueryGenerator.class).warn("Unknown Join type: " + joinType.toString() + " reverting to simple.");
-				newJ.setSimple(true);
-				break;
+		if (joinType != null) {
+			switch (joinType) {
+				case Simple:
+					newJ.setSimple(true);
+					break;
+				case Left:
+					newJ.setLeft(true);
+					break;
+				case Right:
+					newJ.setRight(true);
+					break;
+				case Cross:
+					newJ.setCross(true);
+					break;
+				case Full:
+					newJ.setFull(true);
+					break;
+				case Inner:
+					newJ.setInner(true);
+					break;
+				default:
+					Logger.getLogger(PostgreSQLQueryGenerator.class).warn("Unknown Join type: " + joinType.toString() + " reverting to simple.");
+					newJ.setSimple(true);
+					break;
+			}
 		}
 		if (((PlainSelect) dstStatement.getSelectBody()).getJoins() == null)
 			((PlainSelect) dstStatement.getSelectBody()).setJoins(new ArrayList<>());


### PR DESCRIPTION
The query plan we get back from postgres has a "Join-Type" node that was being ignored resulting in all joins in postgres being interpreted as "simple" joins (essentially inner joins).

This change simply addresses the query generation portion when a "pass-through" query is trying to be done against postgres (joining two tables in the same database), enabling different join types to work, excepting Anti and Semi joins (see the issue for a present discussion about Anti joins).

There's likely additional work to be done to support different joins across multiple database engines, and even on different engines such as MySQL, however this change lays a base for future such work.
